### PR TITLE
Introduces Jackson DateTime module which fixes date serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     compile 'junit:junit:4.12'
     compile 'com.squareup.okhttp3:okhttp:3.6.0'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.8.5'
+    compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.8.5'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.zeroturnaround:zt-exec:1.9'
     compile 'org.slf4j:slf4j-api:1.7.21'

--- a/src/main/java/io/specto/hoverfly/junit/dsl/HttpBodyConverter.java
+++ b/src/main/java/io/specto/hoverfly/junit/dsl/HttpBodyConverter.java
@@ -2,6 +2,8 @@ package io.specto.hoverfly.junit.dsl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * Interface for converting a java object into a http request body, and storing the appropriate content type header value
@@ -14,7 +16,10 @@ public interface HttpBodyConverter {
      * @return the converter
      */
     static HttpBodyConverter json(final Object body) {
-        return json(body, new ObjectMapper());
+        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        return json(body, objectMapper);
     }
 
     /**

--- a/src/test/java/io/specto/hoverfly/models/SimpleBooking.java
+++ b/src/test/java/io/specto/hoverfly/models/SimpleBooking.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 
 public class SimpleBooking {
@@ -15,13 +15,13 @@ public class SimpleBooking {
     private final int id;
     private final String origin;
     private final String destination;
-    private final Date date;
+    private final LocalDate date;
 
     @JsonCreator
     public SimpleBooking(@JsonProperty("id") int id,
                          @JsonProperty("origin") String origin,
                          @JsonProperty("destination") String destination,
-                         @JsonProperty("date") Date date) {
+                         @JsonProperty("date") LocalDate date) {
         this.id = id;
         this.origin = origin;
         this.destination = destination;
@@ -40,7 +40,7 @@ public class SimpleBooking {
         return destination;
     }
 
-    public Date getDate() {
+    public LocalDate getDate() {
         return date;
     }
 

--- a/src/test/java/io/specto/hoverfly/ruletest/HoverflyRuleSslConfigurationTest.java
+++ b/src/test/java/io/specto/hoverfly/ruletest/HoverflyRuleSslConfigurationTest.java
@@ -17,7 +17,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import javax.net.ssl.SSLContext;
 import java.net.URL;
 import java.nio.file.Paths;
-import java.sql.Date;
 import java.time.LocalDate;
 
 import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
@@ -40,7 +39,7 @@ public class HoverflyRuleSslConfigurationTest {
     public void shouldBeAbleToCallHttpsServiceEndpointUsingSelfSignedCertificate() throws Exception {
 
         // Given
-        SimpleBooking booking = new SimpleBooking(1, "London", "Hong Kong", Date.valueOf(LocalDate.now()));
+        SimpleBooking booking = new SimpleBooking(1, "London", "Hong Kong", LocalDate.now());
         hoverflyRule.simulate(dsl(
                 service("https://my-service.com")
                     .get("/api/bookings/1")


### PR DESCRIPTION
While working on #70 I've noticed that one test is failing due to timezone / date serialization issue.

Proposed fix introduces support to LocalDate instead (through jackson-module).

<details>
 <summary>Stacktrace while running `HoverflyRuleSslConfigurationTest`</summary>

```shell
org.junit.ComparisonFailure: 
Expected :io.specto.hoverfly.models.SimpleBooking@1b835480[id=1,origin=London,destination=Hong Kong,date=2017-03-03]
Actual   :io.specto.hoverfly.models.SimpleBooking@4b1d6571[id=1,origin=London,destination=Hong Kong,date=Fri Mar 03 01:00:00 CET 2017]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at io.specto.hoverfly.ruletest.HoverflyRuleSslConfigurationTest.shouldBeAbleToCallHttpsServiceEndpointUsingSelfSignedCertificate(HoverflyRuleSslConfigurationTest.java:63)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:51)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:237)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
```
</details>