### PR TITLE
#82 Improve twice starting error msg

### DIFF
--- a/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
@@ -96,6 +96,11 @@ public class Hoverfly implements AutoCloseable {
 
         Runtime.getRuntime().addShutdownHook(new Thread(this::close));
 
+        if (startedProcess != null) {
+            LOGGER.warn("Your local Hoverfly is already running.");
+            return;
+        }
+
         if (!hoverflyConfig.isRemoteInstance()) {
             startHoverflyProcess();
         }

--- a/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
@@ -97,7 +97,7 @@ public class Hoverfly implements AutoCloseable {
         Runtime.getRuntime().addShutdownHook(new Thread(this::close));
 
         if (startedProcess != null) {
-            LOGGER.warn("Your local Hoverfly is already running.");
+            LOGGER.warn("Local Hoverfly is already running.");
             return;
         }
 

--- a/src/test/java/io/specto/hoverfly/junit/core/HoverflyTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/core/HoverflyTest.java
@@ -126,7 +126,7 @@ public class HoverflyTest {
             public boolean matches(final Object argument) {
                 LoggingEvent event = (LoggingEvent) argument;
                 boolean r = event.getLevel().levelStr.equals("WARN") &&
-                        event.getMessage().contains("Your local Hoverfly is already running");
+                        event.getMessage().contains("Local Hoverfly is already running");
                 return r;
             }
         }));


### PR DESCRIPTION
Fix #82 
Just warning instead of throwing exception when we are trying to call
hoverfly.start twice in the same context.