### PR TITLE
feat: adds new configuration options available in the client

### DIFF
--- a/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
@@ -173,6 +173,15 @@ public class Hoverfly implements AutoCloseable {
             useDefaultSslCert = false;
         }
 
+        if (hoverflyConfig.isWebServer()) {
+            commands.add("-webserver");
+        }
+
+        if (hoverflyConfig.isTlsVerificationDisabled()) {
+            commands.add("-tls-verification");
+            commands.add("false");
+        }
+
         try {
             startedProcess = new ProcessExecutor()
                     .command(commands)

--- a/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfiguration.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfiguration.java
@@ -25,6 +25,8 @@ public class HoverflyConfiguration {
     private String adminCertificate;
     private String proxyCaCertificate;
     private List<String> captureHeaders = Collections.emptyList();
+    private boolean webServer = false;
+    private boolean tlsVerificationDisabled = false;
 
     /**
      * Create configurations for external hoverfly
@@ -161,4 +163,19 @@ public class HoverflyConfiguration {
         this.adminPort = adminPort;
     }
 
+    public boolean isWebServer() {
+        return webServer;
+    }
+
+    public void setWebServer(boolean webServer) {
+        this.webServer = webServer;
+    }
+
+    public boolean isTlsVerificationDisabled() {
+        return tlsVerificationDisabled;
+    }
+
+    public void setTlsVerificationDisabled(boolean tlsVerificationDisabled) {
+        this.tlsVerificationDisabled = tlsVerificationDisabled;
+    }
 }

--- a/src/main/java/io/specto/hoverfly/junit/core/config/LocalHoverflyConfig.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/LocalHoverflyConfig.java
@@ -24,7 +24,8 @@ public class LocalHoverflyConfig extends HoverflyConfig {
     // TODO should be combined field?
     private String sslCertificatePath;
     private String sslKeyPath;
-
+    private boolean webServer;
+    private boolean tlsVerficationDisabled;
 
     /**
      * Sets the SSL certificate file for overriding default Hoverfly self-signed certificate
@@ -49,10 +50,22 @@ public class LocalHoverflyConfig extends HoverflyConfig {
         return this;
     }
 
+    public LocalHoverflyConfig asWebServer() {
+        this.webServer = true;
+        return this;
+    }
+
+    public LocalHoverflyConfig disableTlsVerification() {
+        this.tlsVerficationDisabled = true;
+        return this;
+    }
+
     @Override
     public HoverflyConfiguration build() {
         HoverflyConfiguration configs = new HoverflyConfiguration(proxyPort, adminPort, proxyLocalHost, destination,
                 proxyCaCert, sslCertificatePath, sslKeyPath, captureHeaders);
+        configs.setWebServer(this.webServer);
+        configs.setTlsVerificationDisabled(this.tlsVerficationDisabled);
         HoverflyConfigValidator validator = new HoverflyConfigValidator();
         return validator.validate(configs);
     }

--- a/src/main/java/io/specto/hoverfly/junit/core/model/FieldMatcher.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/model/FieldMatcher.java
@@ -1,14 +1,15 @@
 package io.specto.hoverfly.junit.core.model;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -94,6 +95,8 @@ public class FieldMatcher {
     /**
      * Get pattern which is set for any of the exact/regex matchers
      * Throw exception if no match pattern is available.
+     *
+     * @return first matching pattern
      */
     @JsonIgnore
     public String getMatchPattern() {

--- a/src/test/java/io/specto/hoverfly/junit/core/HoverflyConfigTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/core/HoverflyConfigTest.java
@@ -21,6 +21,7 @@ public class HoverflyConfigTest {
 
         assertThat(configs.getHost()).isEqualTo("localhost");
         assertThat(configs.getScheme()).isEqualTo("http");
+        assertThat(configs.isWebServer()).isFalse();
         assertThat(configs.getAdminPort()).isGreaterThan(0);
         assertThat(configs.getProxyPort()).isGreaterThan(0);
         assertThat(configs.getSslCertificatePath()).isNull();
@@ -28,8 +29,9 @@ public class HoverflyConfigTest {
 
         assertThat(configs.isRemoteInstance()).isFalse();
         assertThat(configs.isProxyLocalHost()).isFalse();
+        assertThat(configs.isWebServer()).isFalse();
+        assertThat(configs.isTlsVerificationDisabled()).isFalse();
     }
-
 
     @Test
     public void shouldHaveDefaultRemoteSettings() throws Exception {
@@ -128,6 +130,20 @@ public class HoverflyConfigTest {
 
         assertThat(configs.getCaptureHeaders()).hasSize(1);
         assertThat(configs.getCaptureHeaders()).containsOnly("*");
+    }
+
+    @Test
+    public void shouldSetWebServerMode() throws Exception {
+        HoverflyConfiguration configs = configs().asWebServer().build();
+
+        assertThat(configs.isWebServer()).isTrue();
+    }
+
+    @Test
+    public void shouldDisableTlsVerification() throws Exception {
+        HoverflyConfiguration configs = configs().disableTlsVerification().build();
+
+        assertThat(configs.isTlsVerificationDisabled()).isTrue();
     }
 
 }


### PR DESCRIPTION
#### `asWebServer` 

Exposes `hoverfly-client` option to act as [web server](http://hoverfly.readthedocs.io/en/latest/pages/keyconcepts/webserver.html).

####  `disableTlsVerfication`  

As `tls-verifaction` is set to `true` by defualt, there is no easy way from the tests to alternate this behaviour of the client.
