### PR TITLE
feat(#160): introduced localConfigs() & remoteConfigs() methods in HoverflyConfig class

### DIFF
--- a/junit5/src/main/java/io/specto/hoverfly/junit5/HoverflyExtensionUtils.java
+++ b/junit5/src/main/java/io/specto/hoverfly/junit5/HoverflyExtensionUtils.java
@@ -4,11 +4,11 @@ import io.specto.hoverfly.junit.core.HoverflyConstants;
 import io.specto.hoverfly.junit.core.SimulationSource;
 import io.specto.hoverfly.junit5.api.HoverflyConfig;
 import io.specto.hoverfly.junit5.api.HoverflySimulate;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.remoteConfigs;
 import static io.specto.hoverfly.junit.core.SimulationSource.defaultPath;
 
 class HoverflyExtensionUtils {
@@ -18,27 +18,20 @@ class HoverflyExtensionUtils {
     static io.specto.hoverfly.junit.core.HoverflyConfig getHoverflyConfigs(HoverflyConfig config) {
 
         if (config != null) {
-            io.specto.hoverfly.junit.core.HoverflyConfig configs = configs()
-                    .sslCertificatePath(config.sslCertificatePath())
-                    .sslKeyPath(config.sslKeyPath())
-                    .adminPort(config.adminPort())
-                    .proxyPort(config.proxyPort())
-                    .destination(config.destination())
-                    .captureHeaders(config.captureHeaders());
+            io.specto.hoverfly.junit.core.HoverflyConfig configs;
 
-            if (config.proxyLocalHost()) {
-                configs.proxyLocalHost();
-            }
-            if (config.captureAllHeaders()) {
-                configs.captureAllHeaders();
-            }
             if (!config.remoteHost().isEmpty()) {
-                configs.remote().host(config.remoteHost());
+                configs = remoteConfigs().host(config.remoteHost());
+            } else {
+                configs = localConfigs()
+                    .sslCertificatePath(config.sslCertificatePath())
+                    .sslKeyPath(config.sslKeyPath());
             }
+            fillHoverflyConfig(configs, config);
             return configs;
 
         } else {
-            return configs();
+            return localConfigs();
         }
     }
 
@@ -71,5 +64,20 @@ class HoverflyExtensionUtils {
             path = HoverflyConstants.DEFAULT_HOVERFLY_EXPORT_PATH;
         }
         return Paths.get(path).resolve(filename);
+    }
+
+    private static void fillHoverflyConfig(io.specto.hoverfly.junit.core.HoverflyConfig configs,
+        HoverflyConfig configParams) {
+        configs
+            .adminPort(configParams.adminPort())
+            .proxyPort(configParams.proxyPort())
+            .destination(configParams.destination())
+            .captureHeaders(configParams.captureHeaders());
+        if (configParams.proxyLocalHost()) {
+            configs.proxyLocalHost();
+        }
+        if (configParams.captureAllHeaders()) {
+            configs.captureAllHeaders();
+        }
     }
 }

--- a/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 import org.zeroturnaround.exec.ProcessExecutor;
 import org.zeroturnaround.exec.StartedProcess;
 
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
 import static io.specto.hoverfly.junit.core.HoverflyMode.CAPTURE;
 import static io.specto.hoverfly.junit.core.HoverflyUtils.checkPortInUse;
 import static io.specto.hoverfly.junit.dsl.matchers.HoverflyMatchers.any;
@@ -103,7 +103,7 @@ public class Hoverfly implements AutoCloseable {
      * @param hoverflyMode the mode
      */
     public Hoverfly(HoverflyMode hoverflyMode) {
-        this(configs(), hoverflyMode);
+        this(localConfigs(), hoverflyMode);
     }
 
     /**

--- a/src/main/java/io/specto/hoverfly/junit/core/HoverflyConfig.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/HoverflyConfig.java
@@ -16,9 +16,7 @@ package io.specto.hoverfly.junit.core;
 import io.specto.hoverfly.junit.core.config.HoverflyConfiguration;
 import io.specto.hoverfly.junit.core.config.LocalHoverflyConfig;
 import io.specto.hoverfly.junit.core.config.RemoteHoverflyConfig;
-
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -39,9 +37,27 @@ public abstract class HoverflyConfig {
     /**
      * New instance
      * @return a {@link LocalHoverflyConfig} implementation
+     * @deprecated use {@link HoverflyConfig#localConfigs()}
      */
+    @Deprecated
     public static LocalHoverflyConfig configs() {
         return new LocalHoverflyConfig();
+    }
+
+    /**
+     * Creates a new instance of {@link LocalHoverflyConfig}
+     * @return A new instance of {@link LocalHoverflyConfig}
+     */
+    public static LocalHoverflyConfig localConfigs() {
+        return new LocalHoverflyConfig();
+    }
+
+    /**
+     * Creates a new instance of {@link RemoteHoverflyConfig}
+     * @return A new instance of {@link RemoteHoverflyConfig}
+     */
+    public static RemoteHoverflyConfig remoteConfigs() {
+        return new RemoteHoverflyConfig();
     }
 
     /**
@@ -143,7 +159,9 @@ public abstract class HoverflyConfig {
     /**
      * Enable remote Hoverfly configurations
      * @return a {@link RemoteHoverflyConfig} implementation
+     * @deprecated use {@link HoverflyConfig#remoteConfigs()}
      */
+    @Deprecated
     public RemoteHoverflyConfig remote() {
         return new RemoteHoverflyConfig();
     }

--- a/src/main/java/io/specto/hoverfly/junit/rule/HoverflyRule.java
+++ b/src/main/java/io/specto/hoverfly/junit/rule/HoverflyRule.java
@@ -12,11 +12,19 @@
  */
 package io.specto.hoverfly.junit.rule;
 
-import io.specto.hoverfly.junit.core.*;
+import io.specto.hoverfly.junit.core.Hoverfly;
+import io.specto.hoverfly.junit.core.HoverflyConfig;
+import io.specto.hoverfly.junit.core.HoverflyConstants;
+import io.specto.hoverfly.junit.core.HoverflyMode;
+import io.specto.hoverfly.junit.core.SimulationSource;
+import io.specto.hoverfly.junit.core.SslConfigurer;
 import io.specto.hoverfly.junit.dsl.HoverflyDsl;
 import io.specto.hoverfly.junit.dsl.RequestMatcherBuilder;
 import io.specto.hoverfly.junit.dsl.StubServiceBuilder;
 import io.specto.hoverfly.junit.verification.VerificationCriteria;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -26,16 +34,15 @@ import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Optional;
-
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
 import static io.specto.hoverfly.junit.core.HoverflyMode.CAPTURE;
 import static io.specto.hoverfly.junit.core.HoverflyMode.SIMULATE;
 import static io.specto.hoverfly.junit.core.SimulationSource.empty;
 import static io.specto.hoverfly.junit.core.SimulationSource.file;
-import static io.specto.hoverfly.junit.rule.HoverflyRuleUtils.*;
+import static io.specto.hoverfly.junit.rule.HoverflyRuleUtils.createTestResourcesHoverflyDirectoryIfNoneExisting;
+import static io.specto.hoverfly.junit.rule.HoverflyRuleUtils.fileRelativeToTestResourcesHoverfly;
+import static io.specto.hoverfly.junit.rule.HoverflyRuleUtils.isAnnotatedWithRule;
+import static io.specto.hoverfly.junit.rule.HoverflyRuleUtils.prettyPrintJson;
 
 
 /**
@@ -109,7 +116,7 @@ public class HoverflyRule extends ExternalResource {
      * @return the rule
      */
     public static HoverflyRule inCaptureOrSimulationMode(String recordFile) {
-        return inCaptureOrSimulationMode(recordFile, configs());
+        return inCaptureOrSimulationMode(recordFile, localConfigs());
     }
 
     /**
@@ -131,7 +138,7 @@ public class HoverflyRule extends ExternalResource {
 
     // TODO default path?
     public static HoverflyRule inCaptureMode() {
-        return inCaptureMode(configs());
+        return inCaptureMode(localConfigs());
     }
 
     public static HoverflyRule inCaptureMode(HoverflyConfig hoverflyConfig) {
@@ -145,7 +152,7 @@ public class HoverflyRule extends ExternalResource {
      * @return the rule
      */
     public static HoverflyRule inCaptureMode(String outputFilename) {
-        return inCaptureMode(outputFilename, configs());
+        return inCaptureMode(outputFilename, localConfigs());
     }
 
     /**
@@ -167,7 +174,7 @@ public class HoverflyRule extends ExternalResource {
      * @return the rule
      */
     public static HoverflyRule inSimulationMode() {
-        return inSimulationMode(configs());
+        return inSimulationMode(localConfigs());
     }
 
     /**
@@ -187,7 +194,7 @@ public class HoverflyRule extends ExternalResource {
      * @return the rule
      */
     public static HoverflyRule inSimulationMode(final SimulationSource simulationSource) {
-        return inSimulationMode(simulationSource, configs());
+        return inSimulationMode(simulationSource, localConfigs());
     }
 
     public static HoverflyRule inSimulationMode(final SimulationSource simulationSource, final HoverflyConfig hoverflyConfig) {

--- a/src/test/java/io/specto/hoverfly/junit/api/HoverflyClientTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/api/HoverflyClientTest.java
@@ -2,10 +2,12 @@ package io.specto.hoverfly.junit.api;
 
 
 import io.specto.hoverfly.junit.rule.HoverflyRule;
-import org.junit.*;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
 import static io.specto.hoverfly.junit.core.SimulationSource.dsl;
 import static io.specto.hoverfly.junit.dsl.HoverflyDsl.service;
 import static io.specto.hoverfly.junit.dsl.ResponseCreators.success;
@@ -18,7 +20,7 @@ public class HoverflyClientTest {
     public EnvironmentVariables envVars = new EnvironmentVariables();
 
     @ClassRule
-    public static HoverflyRule hoverflyRule = HoverflyRule.inSimulationMode(configs().proxyLocalHost());
+    public static HoverflyRule hoverflyRule = HoverflyRule.inSimulationMode(localConfigs().proxyLocalHost());
 
     @Test
     public void shouldBeAbleToCreateNewInstanceOfHoverflyClient() throws Exception {

--- a/src/test/java/io/specto/hoverfly/junit/core/HoverflyConfigTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/core/HoverflyConfigTest.java
@@ -1,13 +1,13 @@
 package io.specto.hoverfly.junit.core;
 
 import io.specto.hoverfly.junit.core.config.HoverflyConfiguration;
+import java.net.InetSocketAddress;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
-import java.net.InetSocketAddress;
-
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.remoteConfigs;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -19,7 +19,7 @@ public class HoverflyConfigTest {
     @Test
     public void shouldHaveDefaultSettings() throws Exception {
 
-        HoverflyConfiguration configs = configs().build();
+        HoverflyConfiguration configs = localConfigs().build();
 
         assertThat(configs.getHost()).isEqualTo("localhost");
         assertThat(configs.getScheme()).isEqualTo("http");
@@ -38,7 +38,7 @@ public class HoverflyConfigTest {
 
     @Test
     public void shouldHaveDefaultRemoteSettings() throws Exception {
-        HoverflyConfiguration configs = HoverflyConfig.configs().remote().build();
+        HoverflyConfiguration configs = HoverflyConfig.remoteConfigs().build();
 
         assertThat(configs.getHost()).isEqualTo("localhost");
         assertThat(configs.getScheme()).isEqualTo("http");
@@ -55,8 +55,7 @@ public class HoverflyConfigTest {
     @Test
     public void shouldBeAbleToOverrideHostNameByUseRemoteInstance() throws Exception {
 
-        HoverflyConfiguration configs = configs()
-                .remote()
+        HoverflyConfiguration configs = remoteConfigs()
                 .host("cloud-hoverfly.com")
                 .build();
 
@@ -66,35 +65,22 @@ public class HoverflyConfigTest {
     }
 
     @Test
-    public void remoteHoverflyConfigShouldIgnoreCustomSslCertAndKey() throws Exception {
-        HoverflyConfiguration configs = configs()
-                .sslCertificatePath("ssl/ca.crt")
-                .sslKeyPath("ssl/ca.key").remote()
-                .remote()
-                .build();
-
-        assertThat(configs.getSslCertificatePath()).isNull();
-        assertThat(configs.getSslKeyPath()).isNull();
-
-    }
-
-    @Test
     public void shouldSetProxyLocalHost() throws Exception {
-        HoverflyConfiguration configs = configs().proxyLocalHost().build();
+        HoverflyConfiguration configs = localConfigs().proxyLocalHost().build();
 
         assertThat(configs.isProxyLocalHost()).isTrue();
     }
 
     @Test
     public void shouldSetPlainHttpTunneling() throws Exception {
-        HoverflyConfiguration configs = configs().plainHttpTunneling().build();
+        HoverflyConfiguration configs = localConfigs().plainHttpTunneling().build();
 
         assertThat(configs.isPlainHttpTunneling()).isTrue();
     }
 
     @Test
     public void shouldSetHttpsAdminEndpoint() throws Exception {
-        HoverflyConfiguration configs = configs().remote().withHttpsAdminEndpoint().build();
+        HoverflyConfiguration configs = remoteConfigs().withHttpsAdminEndpoint().build();
 
         assertThat(configs.getScheme()).isEqualTo("https");
         assertThat(configs.getAdminPort()).isEqualTo(443);
@@ -105,7 +91,7 @@ public class HoverflyConfigTest {
     public void shouldSetAuthTokenFromEnvironmentVariable() throws Exception {
 
         envVars.set(HoverflyConstants.HOVERFLY_AUTH_TOKEN, "token-from-env");
-        HoverflyConfiguration configs = configs().remote().withAuthHeader().build();
+        HoverflyConfiguration configs = remoteConfigs().withAuthHeader().build();
 
         assertThat(configs.getAuthToken()).isPresent();
         configs.getAuthToken().ifPresent(token -> assertThat(token).isEqualTo("token-from-env"));
@@ -113,7 +99,7 @@ public class HoverflyConfigTest {
 
     @Test
     public void shouldSetAuthTokenDirectly() throws Exception {
-        HoverflyConfiguration configs = configs().remote().withAuthHeader("some-token").build();
+        HoverflyConfiguration configs = remoteConfigs().withAuthHeader("some-token").build();
 
         assertThat(configs.getAuthToken()).isPresent();
         configs.getAuthToken().ifPresent(token -> assertThat(token).isEqualTo("some-token"));
@@ -121,7 +107,7 @@ public class HoverflyConfigTest {
 
     @Test
     public void shouldSetCaptureHeaders() throws Exception {
-        HoverflyConfiguration configs = configs().captureHeaders("Accept", "Authorization").build();
+        HoverflyConfiguration configs = localConfigs().captureHeaders("Accept", "Authorization").build();
 
         assertThat(configs.getCaptureHeaders()).hasSize(2);
         assertThat(configs.getCaptureHeaders()).containsOnly("Accept", "Authorization");
@@ -129,7 +115,7 @@ public class HoverflyConfigTest {
 
     @Test
     public void shouldSetCaptureOneHeader() throws Exception {
-        HoverflyConfiguration configs = configs().captureHeaders("Accept").build();
+        HoverflyConfiguration configs = localConfigs().captureHeaders("Accept").build();
 
         assertThat(configs.getCaptureHeaders()).hasSize(1);
         assertThat(configs.getCaptureHeaders()).containsOnly("Accept");
@@ -137,7 +123,7 @@ public class HoverflyConfigTest {
 
     @Test
     public void shouldSetCaptureAllHeaders() throws Exception {
-        HoverflyConfiguration configs = configs().captureAllHeaders().build();
+        HoverflyConfiguration configs = localConfigs().captureAllHeaders().build();
 
         assertThat(configs.getCaptureHeaders()).hasSize(1);
         assertThat(configs.getCaptureHeaders()).containsOnly("*");
@@ -145,28 +131,28 @@ public class HoverflyConfigTest {
 
     @Test
     public void shouldSetWebServerMode() throws Exception {
-        HoverflyConfiguration configs = configs().asWebServer().build();
+        HoverflyConfiguration configs = localConfigs().asWebServer().build();
 
         assertThat(configs.isWebServer()).isTrue();
     }
 
     @Test
     public void shouldDisableTlsVerification() throws Exception {
-        HoverflyConfiguration configs = configs().disableTlsVerification().build();
+        HoverflyConfiguration configs = localConfigs().disableTlsVerification().build();
 
         assertThat(configs.isTlsVerificationDisabled()).isTrue();
     }
 
     @Test
     public void shouldSetMiddleware() {
-        HoverflyConfiguration configs = configs().localMiddleware("python", "foo.py").build();
+        HoverflyConfiguration configs = localConfigs().localMiddleware("python", "foo.py").build();
 
         assertThat(configs.isMiddlewareEnabled()).isTrue();
     }
 
     @Test
     public void shouldSetUpstreamProxy() {
-        HoverflyConfiguration configs = configs().upstreamProxy(new InetSocketAddress("127.0.0.1", 8900)).build();
+        HoverflyConfiguration configs = localConfigs().upstreamProxy(new InetSocketAddress("127.0.0.1", 8900)).build();
 
         assertThat(configs.getUpstreamProxy()).isEqualTo("127.0.0.1:8900");
     }

--- a/src/test/java/io/specto/hoverfly/junit/core/MultiCaptureTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/core/MultiCaptureTest.java
@@ -3,6 +3,12 @@ package io.specto.hoverfly.junit.core;
 import com.google.common.io.Resources;
 import io.specto.hoverfly.junit.rule.HoverflyRule;
 import io.specto.hoverfly.webserver.CaptureModeTestWebServer;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 import org.json.JSONException;
 import org.junit.AfterClass;
@@ -13,14 +19,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
 import static java.nio.charset.Charset.defaultCharset;
 
 public class MultiCaptureTest {
@@ -32,7 +31,7 @@ public class MultiCaptureTest {
     private static final String OTHER_EXPECTED_SIMULATION_JSON = "expected-simulation-other.json";
 
     @Rule
-    public HoverflyRule hoverflyRule = HoverflyRule.inCaptureMode(configs().proxyLocalHost());
+    public HoverflyRule hoverflyRule = HoverflyRule.inCaptureMode(localConfigs().proxyLocalHost());
 
     private URI webServerBaseUrl;
     private RestTemplate restTemplate = new RestTemplate();

--- a/src/test/java/io/specto/hoverfly/junit/core/RemoteHoverflyStubTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/core/RemoteHoverflyStubTest.java
@@ -7,7 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.remoteConfigs;
 import static io.specto.hoverfly.junit.core.HoverflyMode.SIMULATE;
 import static io.specto.hoverfly.junit.core.SimulationSource.dsl;
 import static io.specto.hoverfly.junit.dsl.HoverflyDsl.service;
@@ -40,7 +40,7 @@ public class RemoteHoverflyStubTest {
     public void shouldSetSystemPropertiesForRemoteHoverflyInstance() throws Exception {
 
         // Given
-        try (Hoverfly hoverflyUnderTest = new Hoverfly(configs().remote().host("hoverfly-cloud"), SIMULATE)) {
+        try (Hoverfly hoverflyUnderTest = new Hoverfly(remoteConfigs().host("hoverfly-cloud"), SIMULATE)) {
 
             // When
             hoverflyUnderTest.start();
@@ -60,7 +60,7 @@ public class RemoteHoverflyStubTest {
     public void shouldSetNonProxyHostsWhenUsingBothRemoteHoverflyInstanceAndProxyLocalHost() throws Exception {
 
         // Given
-        try (Hoverfly hoverflyUnderTest = new Hoverfly(configs().remote().host("hoverfly-cloud").proxyLocalHost(), SIMULATE)) {
+        try (Hoverfly hoverflyUnderTest = new Hoverfly(remoteConfigs().host("hoverfly-cloud").proxyLocalHost(), SIMULATE)) {
 
             // When
             hoverflyUnderTest.start();
@@ -74,7 +74,7 @@ public class RemoteHoverflyStubTest {
     public void shouldNotInvokeTempFileManagerWhenUsingRemoteHoverfly() throws Exception {
 
         // Given
-        try (Hoverfly hoverflyUnderTest = new Hoverfly(configs().remote().host("hoverfly-cloud"), SIMULATE)) {
+        try (Hoverfly hoverflyUnderTest = new Hoverfly(remoteConfigs().host("hoverfly-cloud"), SIMULATE)) {
             TempFileManager tempFileManager = mock(TempFileManager.class);
             Whitebox.setInternalState(hoverflyUnderTest, "tempFileManager", tempFileManager);
 

--- a/src/test/java/io/specto/hoverfly/junit/core/RemoteHoverflyTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/core/RemoteHoverflyTest.java
@@ -1,6 +1,8 @@
 package io.specto.hoverfly.junit.core;
 
 import io.specto.hoverfly.junit.core.config.HoverflyConfiguration;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,10 +10,7 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.remoteConfigs;
 import static io.specto.hoverfly.junit.core.HoverflyMode.SIMULATE;
 import static io.specto.hoverfly.junit.core.SimulationSource.classpath;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,8 +29,7 @@ public class RemoteHoverflyTest {
     public void setUp() throws Exception {
         remoteHoverfly.start();
         HoverflyConfiguration remoteConfigs = remoteHoverfly.getHoverflyConfig();
-        localHoverflyDelegate = new Hoverfly(configs()
-                .remote()
+        localHoverflyDelegate = new Hoverfly(remoteConfigs()
                 .adminPort(remoteConfigs.getAdminPort())
                 .proxyPort(remoteConfigs.getProxyPort()), SIMULATE);
         localHoverflyDelegate.start();

--- a/src/test/java/io/specto/hoverfly/junit/core/config/HoverflyConfigValidatorTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/core/config/HoverflyConfigValidatorTest.java
@@ -4,7 +4,8 @@ package io.specto.hoverfly.junit.core.config;
 import org.junit.Before;
 import org.junit.Test;
 
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.remoteConfigs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -21,7 +22,7 @@ public class HoverflyConfigValidatorTest {
     @Test
     public void shouldProvideDefaultPortForRemoteHoverflyInstanceIfNotConfigured() throws Exception {
 
-        HoverflyConfiguration validated = configs().remote().build();
+        HoverflyConfiguration validated = remoteConfigs().build();
 
 
         assertThat(validated.getProxyPort()).isEqualTo(8500);
@@ -31,7 +32,7 @@ public class HoverflyConfigValidatorTest {
     @Test
     public void shouldAssignPortForLocalHoverflyInstanceIfNotConfigured() throws Exception {
 
-        HoverflyConfiguration validated = configs().build();
+        HoverflyConfiguration validated = localConfigs().build();
 
 
         assertThat(validated.getProxyPort()).isNotZero();
@@ -41,7 +42,7 @@ public class HoverflyConfigValidatorTest {
     @Test
     public void shouldThrowExceptionIfOnlySslKeyIsConfigured() throws Exception {
 
-        assertThatThrownBy(() -> configs().sslKeyPath("ssl/ca.key").build())
+        assertThatThrownBy(() -> localConfigs().sslKeyPath("ssl/ca.key").build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Both SSL key and certificate files are required to override the default Hoverfly SSL");
     }
@@ -49,7 +50,7 @@ public class HoverflyConfigValidatorTest {
     @Test
     public void shouldThrowExceptionIfOnlySslCertIsConfigured() throws Exception {
 
-        assertThatThrownBy(() -> configs().sslCertificatePath("ssl/ca.crt").build())
+        assertThatThrownBy(() -> localConfigs().sslCertificatePath("ssl/ca.crt").build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Both SSL key and certificate files are required to override the default Hoverfly SSL");
 
@@ -58,7 +59,7 @@ public class HoverflyConfigValidatorTest {
     @Test
     public void shouldRemoveHttpSchemaFromRemoteInstanceHostName() throws Exception {
 
-        HoverflyConfiguration validated = configs().remote().host("http://100.100.100.1").build();
+        HoverflyConfiguration validated = remoteConfigs().host("http://100.100.100.1").build();
 
         assertThat(validated.getHost()).isEqualTo("100.100.100.1");
     }
@@ -75,15 +76,14 @@ public class HoverflyConfigValidatorTest {
     @Test
     public void shouldSetDefaultHttpsAdminPortTo443() throws Exception {
 
-        HoverflyConfiguration validated = configs().remote().host("remote-host.hoverfly.io").withHttpsAdminEndpoint().build();
+        HoverflyConfiguration validated = remoteConfigs().host("remote-host.hoverfly.io").withHttpsAdminEndpoint().build();
 
         assertThat(validated.getAdminPort()).isEqualTo(443);
     }
 
     @Test
     public void shouldNotChangeUserDefinedHttpsAdminPort() throws Exception {
-        HoverflyConfiguration validated = configs()
-                .remote()
+        HoverflyConfiguration validated = remoteConfigs()
                 .host("remote-host.hoverfly.io")
                 .withHttpsAdminEndpoint()
                 .adminPort(8443)
@@ -95,7 +95,7 @@ public class HoverflyConfigValidatorTest {
     @Test
     public void shouldThrowExceptionIfProxyCaCertDoesNotExist() throws Exception {
 
-        assertThatThrownBy(() -> configs().remote().proxyCaCert("some-cert.pem").build())
+        assertThatThrownBy(() -> remoteConfigs().proxyCaCert("some-cert.pem").build())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Resource not found with name: some-cert.pem");
     }

--- a/src/test/java/io/specto/hoverfly/ruletest/CaptureModeTest.java
+++ b/src/test/java/io/specto/hoverfly/ruletest/CaptureModeTest.java
@@ -6,20 +6,23 @@ import io.specto.hoverfly.junit.core.model.RequestResponsePair;
 import io.specto.hoverfly.junit.core.model.Simulation;
 import io.specto.hoverfly.junit.rule.HoverflyRule;
 import io.specto.hoverfly.webserver.CaptureModeTestWebServer;
-import org.json.JSONException;
-import org.junit.*;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
-import org.springframework.web.client.RestTemplate;
-
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
+import org.json.JSONException;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.web.client.RestTemplate;
 
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
 import static java.nio.charset.Charset.defaultCharset;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,7 +35,7 @@ public class CaptureModeTest {
 
     @Rule
     public HoverflyRule hoverflyRule = HoverflyRule.inCaptureMode(RECORDED_SIMULATION_JSON,
-            configs().captureAllHeaders().proxyLocalHost());
+            localConfigs().captureAllHeaders().proxyLocalHost());
 
     private URI webServerBaseUrl;
     private RestTemplate restTemplate = new RestTemplate();

--- a/src/test/java/io/specto/hoverfly/ruletest/HoverflyRulePortConfigurationTest.java
+++ b/src/test/java/io/specto/hoverfly/ruletest/HoverflyRulePortConfigurationTest.java
@@ -6,9 +6,8 @@ import org.junit.Test;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
 import static io.specto.hoverfly.junit.core.SimulationSource.classpath;
-import static io.specto.hoverfly.junit.core.SimulationSource.defaultPath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -20,7 +19,7 @@ public class HoverflyRulePortConfigurationTest {
     // tag::portConfiguration[]
     @ClassRule
     public static HoverflyRule hoverflyRule = HoverflyRule.inSimulationMode(classpath("test-service.json"),
-            configs().proxyPort(EXPECTED_PROXY_PORT).adminPort(EXPECTED_ADMIN_PORT));
+        localConfigs().proxyPort(EXPECTED_PROXY_PORT).adminPort(EXPECTED_ADMIN_PORT));
     // end::portConfiguration[]
 
     private RestTemplate restTemplate = new RestTemplate();

--- a/src/test/java/io/specto/hoverfly/ruletest/HoverflyRuleRemoteInstanceTest.java
+++ b/src/test/java/io/specto/hoverfly/ruletest/HoverflyRuleRemoteInstanceTest.java
@@ -1,6 +1,8 @@
 package io.specto.hoverfly.ruletest;
 
 import io.specto.hoverfly.junit.rule.HoverflyRule;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -10,10 +12,7 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.remoteConfigs;
 import static io.specto.hoverfly.junit.core.SimulationSource.classpath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.CREATED;
@@ -38,8 +37,7 @@ public class HoverflyRuleRemoteInstanceTest {
 
     @ClassRule
     public static HoverflyRule hoverflyRule = HoverflyRule.inSimulationMode(classpath("test-service-https.json"),
-            configs()
-                    .remote()
+            remoteConfigs()
                     .host(REMOTE_HOST)
                     .withHttpsAdminEndpoint()
                     .withAuthHeader()

--- a/src/test/java/io/specto/hoverfly/ruletest/HoverflyRuleSslConfigurationTest.java
+++ b/src/test/java/io/specto/hoverfly/ruletest/HoverflyRuleSslConfigurationTest.java
@@ -4,6 +4,10 @@ import com.google.common.io.Resources;
 import io.specto.hoverfly.junit.rule.HoverflyRule;
 import io.specto.hoverfly.models.SimpleBooking;
 import io.specto.hoverfly.util.SslUtils;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import javax.net.ssl.SSLContext;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.ClassRule;
@@ -14,12 +18,7 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import javax.net.ssl.SSLContext;
-import java.net.URL;
-import java.nio.file.Paths;
-import java.time.LocalDate;
-
-import static io.specto.hoverfly.junit.core.HoverflyConfig.configs;
+import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
 import static io.specto.hoverfly.junit.core.SimulationSource.dsl;
 import static io.specto.hoverfly.junit.dsl.HoverflyDsl.service;
 import static io.specto.hoverfly.junit.dsl.HttpBodyConverter.json;
@@ -30,7 +29,7 @@ public class HoverflyRuleSslConfigurationTest {
 
     @ClassRule
     public static HoverflyRule hoverflyRule = HoverflyRule.inSimulationMode(
-            configs()
+        localConfigs()
                 .sslCertificatePath("ssl/ca.crt")
                 .sslKeyPath("ssl/ca.key")
     );

--- a/src/test/java/io/specto/hoverfly/ruletest/LocalMiddlewareTest.java
+++ b/src/test/java/io/specto/hoverfly/ruletest/LocalMiddlewareTest.java
@@ -24,7 +24,7 @@ public class LocalMiddlewareTest {
       service("www.other-anotherservice.com")
          .put("/api/bookings/1").body("{\"flightId\": \"1\", \"class\": \"PREMIUM\"}")
          .willReturn(success())),
-      HoverflyConfig.configs().localMiddleware("python", "middleware/middleware.py")).printSimulationData();
+      HoverflyConfig.localConfigs().localMiddleware("python", "middleware/middleware.py")).printSimulationData();
 
    private final RestTemplate restTemplate = new RestTemplate();
 

--- a/src/test/java/io/specto/hoverfly/ruletest/ReactorNettyTest.java
+++ b/src/test/java/io/specto/hoverfly/ruletest/ReactorNettyTest.java
@@ -18,7 +18,7 @@ import static io.specto.hoverfly.junit.core.SimulationSource.classpath;
 public class ReactorNettyTest {
 
     @ClassRule
-    public static HoverflyRule hoverflyRule = HoverflyRule.inSimulationMode(classpath("test-service.json"), HoverflyConfig.configs().plainHttpTunneling());
+    public static HoverflyRule hoverflyRule = HoverflyRule.inSimulationMode(classpath("test-service.json"), HoverflyConfig.localConfigs().plainHttpTunneling());
 
     @Test
     public void hoverflyProxy() throws Exception {


### PR DESCRIPTION
Introduced `HoverflyConfig.localConfigs()` & `HoverflyConfig.remoteConfigs()` methods to make clear which type of `HoverflyConfig` is being created.
The methdos `HoverflyConfig.configs()` & `HoverflyConfig.remote()` has been deprecated.

Part of this PR is also a fix of the JUnit 5 extension - originally, nothing but the remote host has been set.

fixes: #160 