### PR TITLE
#169 Output Hoverfly binary logs using SLF4J rather than stdout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     testCompile 'com.google.guava:guava:20.0'
     testCompile 'org.springframework:spring-web:4.3.8.RELEASE'
     testCompile 'org.apache.httpcomponents:httpclient:4.5.2'
-    testCompile 'org.assertj:assertj-core:3.6.1'
+    testCompile 'org.assertj:assertj-core:3.9.1'
     testCompile 'net.javacrumbs.json-unit:json-unit:1.17.0'
     testCompile 'net.javacrumbs.json-unit:json-unit-fluent:1.17.0'
     testCompile 'org.eclipse.jetty:jetty-server:9.3.11.v20160721'

--- a/src/main/java/io/specto/hoverfly/junit/core/LoggingOutputStream.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/LoggingOutputStream.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this classpath except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * <p>
+ * Copyright 2016-2016 SpectoLabs Ltd.
+ */
+package io.specto.hoverfly.junit.core;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+
+import static java.util.stream.Collectors.joining;
+
+/**
+ * An {@code OutputStream} designed to take in the Hoverfly JSON structured and log it correctly.
+ */
+class LoggingOutputStream extends OutputStream {
+
+    private final ByteArrayOutputStream stream = new ByteArrayOutputStream(1000);
+    private final Logger logger;
+
+    private static final ObjectMapper LOG_PARSER = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    LoggingOutputStream(final Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void write(final int b) {
+        if (b == '\n') {
+            final String line = stream.toString();
+            stream.reset();
+
+            try {
+                final Map<?, ?> logLine = LOG_PARSER.readValue(line, Map.class);
+                final String message = String.valueOf(logLine.remove("msg"));
+                final String level = String.valueOf(logLine.remove("level"));
+                logLine.remove("time");
+                log(level, message, logLine);
+            } catch (IOException e) {
+                // Unparseable log message so only option is to just log the entire message
+                logger.info(line);
+            }
+
+        } else {
+            stream.write(b);
+        }
+    }
+
+    private void log(final String level, final String message, final Map<?, ?> details) {
+        switch (level) {
+            case "panic":
+            case "fatal":
+            case "error":
+                logger.error("{} {}", message, new MapToString(details));
+                break;
+            case "warning":
+                logger.warn("{} {}", message, new MapToString(details));
+                break;
+            default:
+                // fall through
+            case "info":
+                logger.info("{} {}", message, new MapToString(details));
+                break;
+            case "debug":
+                logger.debug("{} {}", message, new MapToString(details));
+                break;
+        }
+    }
+
+    private static class MapToString {
+        private final Map<?, ?> delegate;
+
+        private MapToString(final Map<?, ?> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String toString() {
+            return delegate.isEmpty() ? "" : delegate.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(joining(" "));
+        }
+    }
+}

--- a/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfiguration.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfiguration.java
@@ -1,6 +1,8 @@
 package io.specto.hoverfly.junit.core.config;
 
 import io.specto.hoverfly.junit.core.Hoverfly;
+import org.slf4j.Logger;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -31,6 +33,7 @@ public class HoverflyConfiguration {
     private boolean tlsVerificationDisabled;
     private boolean plainHttpTunneling;
     private String upstreamProxy;
+    private Optional<Logger> hoverflyLogger;
 
     /**
      * Create configurations for external hoverfly
@@ -46,7 +49,7 @@ public class HoverflyConfiguration {
                           final String adminCertificate,
                           final List<String> captureHeaders,
                           final boolean webServer) {
-        this(proxyPort, adminPort, proxyLocalHost, destination, proxyCaCertificate, captureHeaders, webServer);
+        this(proxyPort, adminPort, proxyLocalHost, destination, proxyCaCertificate, captureHeaders, webServer, Optional.empty());
         setScheme(scheme);
         setHost(host);
         this.authToken = authToken;
@@ -63,7 +66,8 @@ public class HoverflyConfiguration {
                           final String destination,
                           final String proxyCaCertificate,
                           final List<String> captureHeaders,
-                          final boolean webServer) {
+                          final boolean webServer,
+                          final Optional<Logger> hoverflyLogger) {
         this.proxyPort = proxyPort;
         this.adminPort = adminPort;
         this.proxyLocalHost = proxyLocalHost;
@@ -71,6 +75,7 @@ public class HoverflyConfiguration {
         this.proxyCaCertificate = proxyCaCertificate;
         this.captureHeaders = captureHeaders;
         this.webServer = webServer;
+        this.hoverflyLogger = hoverflyLogger;
     }
 
     /**
@@ -216,6 +221,10 @@ public class HoverflyConfiguration {
 
     public boolean isMiddlewareEnabled() {
         return localMiddleware != null && isNotBlank(localMiddleware.getBinary()) && isNotBlank(localMiddleware.getPath());
+    }
+
+    public Optional<Logger> getHoverflyLogger() {
+        return hoverflyLogger;
     }
 
     private boolean isNotBlank(String str) {

--- a/src/main/java/io/specto/hoverfly/junit/core/config/LocalHoverflyConfig.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/LocalHoverflyConfig.java
@@ -12,11 +12,13 @@
  */
 package io.specto.hoverfly.junit.core.config;
 
-
 import io.specto.hoverfly.junit.core.Hoverfly;
 import io.specto.hoverfly.junit.core.HoverflyConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
+import java.util.Optional;
 
 /**
  * Config builder interface for settings specific to {@link Hoverfly} managed internally
@@ -30,6 +32,7 @@ public class LocalHoverflyConfig extends HoverflyConfig {
     private boolean plainHttpTunneling;
     private LocalMiddleware localMiddleware;
     private String upstreamProxy;
+    private Optional<Logger> hoverflyLogger = Optional.ofNullable(LoggerFactory.getLogger("hoverfly"));
 
     /**
      * Sets the SSL certificate file for overriding default Hoverfly self-signed certificate
@@ -99,10 +102,29 @@ public class LocalHoverflyConfig extends HoverflyConfig {
         return this;
     }
 
+    /**
+     * Set the name of the logger to use when logging the output of the Hoverfly binary.
+     * @param loggerName Name of the logger to use when logging the output of the Hoverfly binary.
+     * @return the {@link HoverflyConfig} for further customizations
+     */
+    public LocalHoverflyConfig logger(final String loggerName) {
+        this.hoverflyLogger = Optional.ofNullable(loggerName).map(LoggerFactory::getLogger);
+        return this;
+    }
+
+    /**
+     * Change the Hoverfly binary to output directly to {@link System#out}.
+     * @return the {@link HoverflyConfig} for further customizations
+     */
+    public LocalHoverflyConfig logToStdOut() {
+        this.hoverflyLogger = Optional.empty();
+        return this;
+    }
+
     @Override
     public HoverflyConfiguration build() {
         HoverflyConfiguration configs = new HoverflyConfiguration(proxyPort, adminPort, proxyLocalHost, destination,
-                proxyCaCert, captureHeaders, webServer);
+                proxyCaCert, captureHeaders, webServer, hoverflyLogger);
         configs.setSslCertificatePath(this.sslCertificatePath);
         configs.setSslKeyPath(this.sslKeyPath);
         configs.setTlsVerificationDisabled(this.tlsVerificationDisabled);

--- a/src/test/java/io/specto/hoverfly/ruletest/NonClassRuleHoverflyRuleTest.java
+++ b/src/test/java/io/specto/hoverfly/ruletest/NonClassRuleHoverflyRuleTest.java
@@ -49,7 +49,7 @@ public class NonClassRuleHoverflyRuleTest {
     @BeforeClass
     public static void init() {
         appender = Mockito.mock(Appender.class);
-        Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        Logger logger = (Logger) LoggerFactory.getLogger(HoverflyRule.class);
         logger.addAppender(appender);
         logger.setAdditive(false);
         logger.setLevel(Level.WARN);

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<configuration scan="false" debug="true">
+<configuration scan="false" debug="false">
     <property name="LOG_LEVEL" value="INFO"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
Forward the logs from the Hoverfly binary to SLF4J, so can be controlled through standard logging configuration, rather than to `System.out`.

Also avoid having `Hoverfly.close` called multiple times when the `HoverflyRule` gets called correctly.

Fixes #169