### PR TITLE
Fail-Early for LocalMiddlewareTest

### DIFF
--- a/src/test/java/io/specto/hoverfly/ruletest/LocalMiddlewareTest.java
+++ b/src/test/java/io/specto/hoverfly/ruletest/LocalMiddlewareTest.java
@@ -2,14 +2,16 @@ package io.specto.hoverfly.ruletest;
 
 import io.specto.hoverfly.junit.core.HoverflyConfig;
 import io.specto.hoverfly.junit.rule.HoverflyRule;
-import java.net.URI;
-import java.net.URISyntaxException;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import static io.specto.hoverfly.junit.core.SimulationSource.dsl;
 import static io.specto.hoverfly.junit.dsl.HoverflyDsl.service;
@@ -28,8 +30,18 @@ public class LocalMiddlewareTest {
 
    private final RestTemplate restTemplate = new RestTemplate();
 
+   private static void requirePython() {
+      try {
+         Runtime.getRuntime().exec("python");
+      } catch (IOException e) {
+         throw new IllegalStateException("Required executable 'python' not available. Please install prior to executing this test.");
+      }
+   }
+
    @Test
    public void shouldBeAbleToChangeStatusCodeUsingHoverflyLocalMiddleware() throws URISyntaxException {
+      requirePython();
+
       // Given
       final RequestEntity<String> bookFlightRequest =
          RequestEntity.put(new URI("http://www.other-anotherservice.com/api/bookings/1"))


### PR DESCRIPTION
If Python is not installed `LocalMiddlewareTest` will fail with 502 Bad Gateway response. It is not that obvious, that the actual problem is, that Python is not installed.

The test now checks before test execution if Python is available and fails with an appropriate message.

As an alternative, I suggest adding Python as a requirement to the development requirements in `README.adoc`.