### PR TITLE
Add binaryLocation to start hoverfly locally from custom location

### DIFF
--- a/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
@@ -169,7 +169,7 @@ public class Hoverfly implements AutoCloseable {
 
         final SystemConfig systemConfig = new SystemConfigFactory(hoverflyConfig).createSystemConfig();
 
-        if (Objects.nonNull(hoverflyConfig.getBinaryLocation())) {
+        if (hoverflyConfig.getBinaryLocation() != null) {
             tempFileManager.setBinaryLocation(hoverflyConfig.getBinaryLocation());
         }
         Path binaryPath = tempFileManager.copyHoverflyBinary(systemConfig);

--- a/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -168,6 +169,9 @@ public class Hoverfly implements AutoCloseable {
 
         final SystemConfig systemConfig = new SystemConfigFactory(hoverflyConfig).createSystemConfig();
 
+        if (Objects.nonNull(hoverflyConfig.getBinaryLocation())) {
+            tempFileManager.setBinaryLocation(hoverflyConfig.getBinaryLocation());
+        }
         Path binaryPath = tempFileManager.copyHoverflyBinary(systemConfig);
 
         LOGGER.info("Executing binary at {}", binaryPath);

--- a/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/Hoverfly.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;

--- a/src/main/java/io/specto/hoverfly/junit/core/TempFileManager.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/TempFileManager.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.Objects;
 
 import static io.specto.hoverfly.junit.core.HoverflyUtils.findResourceOnClasspath;
 import static io.specto.hoverfly.junit.core.SystemConfigFactory.OsName.WINDOWS;
@@ -106,6 +107,12 @@ class TempFileManager {
         }
 
         return tempDirectory;
+    }
+
+    void setBinaryLocation(String binaryLocation) {
+        if (Objects.nonNull(binaryLocation)) {
+            this.tempDirectory = new File(binaryLocation).toPath();
+        }
     }
 
 }

--- a/src/main/java/io/specto/hoverfly/junit/core/TempFileManager.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/TempFileManager.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashSet;
 
 import static io.specto.hoverfly.junit.core.HoverflyUtils.findResourceOnClasspath;
@@ -109,7 +110,7 @@ class TempFileManager {
     }
 
     void setBinaryLocation(String binaryLocation) {
-        this.tempDirectory = new File(binaryLocation).toPath();
+        this.tempDirectory = Paths.get(binaryLocation);
     }
 
 }

--- a/src/main/java/io/specto/hoverfly/junit/core/TempFileManager.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/TempFileManager.java
@@ -10,7 +10,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
-import java.util.Objects;
 
 import static io.specto.hoverfly.junit.core.HoverflyUtils.findResourceOnClasspath;
 import static io.specto.hoverfly.junit.core.SystemConfigFactory.OsName.WINDOWS;

--- a/src/main/java/io/specto/hoverfly/junit/core/TempFileManager.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/TempFileManager.java
@@ -110,9 +110,7 @@ class TempFileManager {
     }
 
     void setBinaryLocation(String binaryLocation) {
-        if (Objects.nonNull(binaryLocation)) {
-            this.tempDirectory = new File(binaryLocation).toPath();
-        }
+        this.tempDirectory = new File(binaryLocation).toPath();
     }
 
 }

--- a/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfiguration.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfiguration.java
@@ -40,6 +40,7 @@ public class HoverflyConfiguration {
     private SimulationPreprocessor simulationPreprocessor;
     private String binaryNameFormat;
     private List<String> commands;
+    private String binaryLocation;
 
     /**
      * Create configurations for external hoverfly
@@ -285,5 +286,13 @@ public class HoverflyConfiguration {
 
     public void setCommands(List<String> commands) {
         this.commands = commands;
+    }
+
+    public void setBinaryLocation(String binaryLocation) {
+        this.binaryLocation = binaryLocation;
+    }
+
+    public String getBinaryLocation() {
+        return binaryLocation;
     }
 }

--- a/src/main/java/io/specto/hoverfly/junit/core/config/LocalHoverflyConfig.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/LocalHoverflyConfig.java
@@ -37,6 +37,7 @@ public class LocalHoverflyConfig extends HoverflyConfig {
     private Logger hoverflyLogger = LoggerFactory.getLogger("hoverfly");
     private LogLevel logLevel;
     private List<String> commands = new LinkedList<>();
+    private String binaryLocation;
 
     /**
      * Sets the SSL certificate file for overriding default Hoverfly self-signed certificate
@@ -158,9 +159,13 @@ public class LocalHoverflyConfig extends HoverflyConfig {
         configs.setLocalMiddleware(localMiddleware);
         configs.setUpstreamProxy(upstreamProxy);
         configs.setCommands(commands);
+        configs.setBinaryLocation(binaryLocation);
         HoverflyConfigValidator validator = new HoverflyConfigValidator();
         return validator.validate(configs);
     }
 
-
+    public HoverflyConfig binaryLocation(String binaryLocation) {
+        this.binaryLocation = binaryLocation;
+        return this;
+    }
 }

--- a/src/test/java/io/specto/hoverfly/junit/core/HoverflyTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/core/HoverflyTest.java
@@ -45,7 +45,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
 import static io.specto.hoverfly.junit.core.HoverflyConfig.remoteConfigs;
@@ -653,7 +652,7 @@ public class HoverflyTest {
     @Test
     public void shouldStartHoverflyFromCustomBinaryLocation() {
         final String os = System.getProperty("os.name").toLowerCase();
-        assumeTrue("Currently this case is tested only in Windows, in Linux ps may be used", os.indexOf("windows") != -1);
+        assumeTrue("Currently this case is tested only in Windows, in Linux ps may be used", os.contains("windows"));
 
         final String binaryLocation = "build/tmp";
         clearBinaryFiles(binaryLocation);
@@ -663,7 +662,7 @@ public class HoverflyTest {
 
         final String actualPath = findProcessDirectory(binaryLocation);
         assertThat(actualPath).contains(binaryLocation.replace('/', File.separatorChar));
-        
+
         final File[] exes = getBinaryFiles(binaryLocation);
         assertThat(exes.length).isEqualTo(1);
     }
@@ -675,7 +674,7 @@ public class HoverflyTest {
     private File[] getBinaryFiles(final String binaryLocation) {
         final File binaryDir = new File(binaryLocation);
         final File[] exes = binaryDir.listFiles((f) -> f.getName().endsWith("exe"));
-        if (Objects.isNull(exes)) {
+        if (exes == null) {
             return new File[0];
         }
         return exes;


### PR DESCRIPTION
i. why you made it

In some windows machine, non-admin user can't start process from local temp directory due to group policy, so it's better to start hoverfly process from a custom location.

This custom location is meaningless for hoverfly process started from command line, so it's unnecessary to expose it as command line argument.

ii. how to test it

* Add a test case named 'shouldStartHoverflyFromCustomBinaryLocation' in HoverflyTest, and update localConfigs() to set the custom binary location
* Removing compiler errors by add binaryLocation property in related classes including LocalHoverflyConfig/HoverflyConfiguration/TempFileManager
* Before starting hoverfly process in Hoverfly.java, set this binaryLocation to tempDirectory of TempFileManager
* TempFileManager always checks the nullibility of tempDirectory, so if it were not null, then the binary will be copied to the custom location.

iii. any information about testing you have performed

Using powershell to verify the process is started from the custom location, so it's only tested on Windows platform (using assumeTrue)