### PR TITLE
Increase visibility of HoverflyExtension#getPath

### DIFF
--- a/junit5/src/main/java/io/specto/hoverfly/junit5/HoverflyExtension.java
+++ b/junit5/src/main/java/io/specto/hoverfly/junit5/HoverflyExtension.java
@@ -119,7 +119,14 @@ public class HoverflyExtension implements AfterEachCallback, BeforeEachCallback,
         }
     }
 
-    private String getPath(ExtensionContext context, HoverflySimulate.Source source) {
+    /**
+     * Returns the path to the simulation source.
+     *
+     * @param context the current extension context; never {@code null}
+     * @param source  the simulation source annotation; never {@code null}
+     * @return the path to the simulation source
+     */
+    protected String getPath(ExtensionContext context, HoverflySimulate.Source source) {
         String path = source.value();
 
         if (path.isEmpty()) {


### PR DESCRIPTION
Increasing the visibility to `protected` allows to override it for
customizations.

I need two suites to simulate calls to two two different major versions of a software - where paths and contents may differ quite much. To achieve this, I'd like to extend the `HoverflyExtension` and overwrite the `getPath` method and prepend the path with a folder for each suite, e.g. controlled by a system property.

I'll provide a test for this in a subsequent PR (after may holidays ;) ), but would like get the increased visibility in the next release by chance. Time's running out today to provide a well-implemented test...

Many thanks in advance!