### PR TITLE
Fix port conflict when running multiple unit tests in parallel

### DIFF
--- a/src/main/java/io/specto/hoverfly/junit/api/HoverflyClient.java
+++ b/src/main/java/io/specto/hoverfly/junit/api/HoverflyClient.java
@@ -7,7 +7,6 @@ import io.specto.hoverfly.junit.api.model.ModeArguments;
 import io.specto.hoverfly.junit.api.view.DiffView;
 import io.specto.hoverfly.junit.api.view.HoverflyInfoView;
 import io.specto.hoverfly.junit.api.view.StateView;
-import io.specto.hoverfly.junit.core.HoverflyConstants;
 import io.specto.hoverfly.junit.core.HoverflyMode;
 import io.specto.hoverfly.junit.core.model.Journal;
 import io.specto.hoverfly.junit.core.model.Request;
@@ -93,63 +92,5 @@ public interface HoverflyClient {
      * @return the status of Hoverfly
      */
     boolean getHealth();
-
-    /**
-     * Static factory method for creating a {@link Builder}
-     * @return a builder for HoverflyClient
-     */
-    static Builder custom() {
-        return new Builder();
-    }
-
-    /**
-     * Static factory method for default Hoverfly client
-     * @return a default HoverflyClient
-     */
-    static HoverflyClient createDefault() {
-        return new Builder().build();
-    }
-
-    /**
-     * HTTP client builder for Hoverfly admin API
-     */
-    class Builder {
-
-        private String scheme = HoverflyConstants.HTTP;
-        private String host = HoverflyConstants.LOCALHOST;
-        private int port = HoverflyConstants.DEFAULT_ADMIN_PORT;
-        private String authToken = null;
-
-        Builder() {
-        }
-
-        public Builder scheme(String scheme) {
-            this.scheme = scheme;
-            return this;
-        }
-
-        public Builder host(String host) {
-            this.host = host;
-            return this;
-        }
-
-        public Builder port(int port) {
-            this.port = port;
-            return this;
-        }
-
-        /**
-         * Get token from environment variable "HOVERFLY_AUTH_TOKEN" to authenticate with admin API
-         * @return this Builder for further customizations
-         */
-        public Builder withAuthToken() {
-            this.authToken = System.getenv(HoverflyConstants.HOVERFLY_AUTH_TOKEN);
-            return this;
-        }
-
-        public HoverflyClient build() {
-            return new OkHttpHoverflyClient(scheme, host, port, authToken);
-        }
-    }
 
 }

--- a/src/main/java/io/specto/hoverfly/junit/api/HoverflyClientFactory.java
+++ b/src/main/java/io/specto/hoverfly/junit/api/HoverflyClientFactory.java
@@ -1,0 +1,12 @@
+package io.specto.hoverfly.junit.api;
+
+import io.specto.hoverfly.junit.core.config.HoverflyConfiguration;
+
+/**
+ * Factory for creating {@link HoverflyClient}s
+ */
+public interface HoverflyClientFactory {
+
+    HoverflyClient createHoverflyClient(HoverflyConfiguration hoverflyConfig);
+
+}

--- a/src/main/java/io/specto/hoverfly/junit/api/HoverflyOkHttpClientFactory.java
+++ b/src/main/java/io/specto/hoverfly/junit/api/HoverflyOkHttpClientFactory.java
@@ -1,0 +1,75 @@
+package io.specto.hoverfly.junit.api;
+
+import io.specto.hoverfly.junit.core.HoverflyConstants;
+import io.specto.hoverfly.junit.core.config.HoverflyConfiguration;
+
+public class HoverflyOkHttpClientFactory implements HoverflyClientFactory {
+
+    public HoverflyClient createHoverflyClient(HoverflyConfiguration hoverflyConfig) {
+        return custom()
+                .scheme(hoverflyConfig.getScheme())
+                .host(hoverflyConfig.getHost())
+                .port(hoverflyConfig.getAdminPort())
+                .withAuthToken()
+                .build();
+    }
+
+    /**
+     * Static factory method for creating a {@link Builder}
+     * @return a builder for HoverflyClient
+     */
+    static Builder custom() {
+        return new Builder();
+    }
+
+    /**
+     * Static factory method for default Hoverfly client
+     * @return a default HoverflyClient
+     */
+    static HoverflyClient createDefault() {
+        return new Builder().build();
+    }
+
+    /**
+     * HTTP client builder for Hoverfly admin API
+     */
+    static class Builder {
+
+        private String scheme = HoverflyConstants.HTTP;
+        private String host = HoverflyConstants.LOCALHOST;
+        private int port = HoverflyConstants.DEFAULT_ADMIN_PORT;
+        private String authToken = null;
+
+        Builder() {
+        }
+
+        public Builder scheme(String scheme) {
+            this.scheme = scheme;
+            return this;
+        }
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        /**
+         * Get token from environment variable "HOVERFLY_AUTH_TOKEN" to authenticate with admin API
+         * @return this Builder for further customizations
+         */
+        public Builder withAuthToken() {
+            this.authToken = System.getenv(HoverflyConstants.HOVERFLY_AUTH_TOKEN);
+            return this;
+        }
+
+        public HoverflyClient build() {
+            return new OkHttpHoverflyClient(scheme, host, port, authToken);
+        }
+    }
+
+}

--- a/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfigValidator.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfigValidator.java
@@ -47,15 +47,7 @@ class HoverflyConfigValidator {
             if (isKeyBlank && !isCertBlank || !isKeyBlank && isCertBlank) {
                 throw new IllegalArgumentException("Both SSL key and certificate files are required to override the default Hoverfly SSL.");
             }
-            // Validate proxy port
-            if (hoverflyConfig.getProxyPort() == 0) {
-                hoverflyConfig.setProxyPort(findUnusedPort());
-            }
 
-            // Validate admin port
-            if (hoverflyConfig.getAdminPort() == 0) {
-                hoverflyConfig.setAdminPort(findUnusedPort());
-            }
         }
 
         // Check proxy CA cert exists
@@ -64,18 +56,6 @@ class HoverflyConfigValidator {
         }
 
         return hoverflyConfig;
-    }
-
-
-    /**
-     * Looks for an unused port on the current machine
-     */
-    private static int findUnusedPort() {
-        try (final ServerSocket serverSocket = new ServerSocket(0)) {
-            return serverSocket.getLocalPort();
-        } catch (IOException e) {
-            throw new RuntimeException("Cannot find available port", e);
-        }
     }
 
     private void checkResourceOnClasspath(String resourceName) {

--- a/src/test/java/io/specto/hoverfly/junit/api/HoverflyOkHttpClientFactoryTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/api/HoverflyOkHttpClientFactoryTest.java
@@ -13,7 +13,7 @@ import static io.specto.hoverfly.junit.dsl.HoverflyDsl.service;
 import static io.specto.hoverfly.junit.dsl.ResponseCreators.success;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HoverflyClientTest {
+public class HoverflyOkHttpClientFactoryTest {
 
 
     @Rule
@@ -30,7 +30,7 @@ public class HoverflyClientTest {
                     .get("/api/health")
                     .willReturn(success())
         ));
-        HoverflyClient hoverflyClient = HoverflyClient.custom()
+        HoverflyClient hoverflyClient = HoverflyOkHttpClientFactory.custom()
                 .port(9999)
                 .build();
 
@@ -46,7 +46,7 @@ public class HoverflyClientTest {
                         .header("Authorization", "Bearer some-token")
                     .willReturn(success())
         ));
-        HoverflyClient hoverflyClient = HoverflyClient.custom()
+        HoverflyClient hoverflyClient = HoverflyOkHttpClientFactory.custom()
                 .host("remote.host")
                 .port(12345)
                 .withAuthToken()
@@ -62,7 +62,7 @@ public class HoverflyClientTest {
                     .get("/api/health")
                     .willReturn(success())
         ));
-        HoverflyClient defaultClient = HoverflyClient.createDefault();
+        HoverflyClient defaultClient = HoverflyOkHttpClientFactory.createDefault();
 
         assertThat(defaultClient.getHealth()).isTrue();
     }

--- a/src/test/java/io/specto/hoverfly/junit/core/HoverflyConfigTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/core/HoverflyConfigTest.java
@@ -28,8 +28,6 @@ public class HoverflyConfigTest {
         assertThat(configs.getHost()).isEqualTo("localhost");
         assertThat(configs.getScheme()).isEqualTo("http");
         assertThat(configs.isWebServer()).isFalse();
-        assertThat(configs.getAdminPort()).isGreaterThan(0);
-        assertThat(configs.getProxyPort()).isGreaterThan(0);
         assertThat(configs.getSslCertificatePath()).isNull();
         assertThat(configs.getSslKeyPath()).isNull();
 

--- a/src/test/java/io/specto/hoverfly/junit/core/config/HoverflyConfigValidatorTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/core/config/HoverflyConfigValidatorTest.java
@@ -30,16 +30,6 @@ public class HoverflyConfigValidatorTest {
     }
 
     @Test
-    public void shouldAssignPortForLocalHoverflyInstanceIfNotConfigured() {
-
-        HoverflyConfiguration validated = localConfigs().build();
-
-
-        assertThat(validated.getProxyPort()).isNotZero();
-        assertThat(validated.getAdminPort()).isNotZero();
-    }
-
-    @Test
     public void shouldThrowExceptionIfOnlySslKeyIsConfigured() {
 
         assertThatThrownBy(() -> localConfigs().sslKeyPath("ssl/ca.key").build())


### PR DESCRIPTION
The "random" port selection can still lead to port conflicts, when running multiple unit tests in parallel. 

This is because port selection and check is done within the config validation phase, but the actual port binding is done later when the hoverfly process is started. Example:
1. Thread A selects free port, eg. 49999 (Port is not bound yet)
2. Thread B selects same port
3. Thread A starts hoverfly process on port 49999 (Port is bound now)
4. Thread B starts hoverfly process on port 49999 -> IllegalStateException

Fixed by moving port selection from validation to Hoverfly.startHoverflyProcess and synchronizing on Hoverfly.class.