### PR TITLE
Update with non-deprecated method

### DIFF
--- a/docs/pages/corefunctionality/capturing.rst
+++ b/docs/pages/corefunctionality/capturing.rst
@@ -9,7 +9,7 @@ test, then switch back into simulate mode using the simulation data recorded dur
 
 .. code-block:: java
 
-    try(Hoverfly hoverfly = new Hoverfly(configs(), CAPTURE)) {
+    try(Hoverfly hoverfly = new Hoverfly(localConfigs(), CAPTURE)) {
 
         hoverfly.start();
 


### PR DESCRIPTION
`HoverFlyConfig.configs()` is deprecated, use instead `HoverflyConfig.localConfigs()`