### PR TITLE
Implementing POST request for appending simulation

### DIFF
--- a/src/main/java/io/specto/hoverfly/junit/api/HoverflyClient.java
+++ b/src/main/java/io/specto/hoverfly/junit/api/HoverflyClient.java
@@ -110,6 +110,8 @@ public interface HoverflyClient {
         return new Builder().build();
     }
 
+    void addSimulation(Simulation simulation);
+
     /**
      * HTTP client builder for Hoverfly admin API
      */

--- a/src/main/java/io/specto/hoverfly/junit/api/OkHttpHoverflyClient.java
+++ b/src/main/java/io/specto/hoverfly/junit/api/OkHttpHoverflyClient.java
@@ -49,7 +49,7 @@ class OkHttpHoverflyClient implements HoverflyClient {
     OkHttpHoverflyClient(String scheme, String host, int port, String authToken) {
         OBJECT_MAPPER.registerModule(new JavaTimeModule());
         OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
-        if (authToken != null ) {
+        if (authToken != null) {
             clientBuilder.addInterceptor(new AuthHeaderInterceptor(authToken));
         }
         this.client = clientBuilder.build();
@@ -83,6 +83,19 @@ class OkHttpHoverflyClient implements HoverflyClient {
         } catch (Exception e) {
             LOGGER.warn("Failed to set simulation: {}", e.getMessage());
             throw new HoverflyClientException("Failed to set simulation: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void addSimulation(Simulation simulation) {
+        try {
+            final Request.Builder builder = createRequestBuilderWithUrl(SIMULATION_PATH);
+            final RequestBody body = createRequestBody(simulation);
+            final Request request = builder.post(body).build();
+            exchange(request);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to add simulation: {}", e.getMessage());
+            throw new HoverflyClientException("Failed to add simulation: " + e.getMessage());
         }
     }
 
@@ -184,7 +197,7 @@ class OkHttpHoverflyClient implements HoverflyClient {
             throw new HoverflyClientException("Failed to get state: " + e.getMessage());
         }
     }
-  
+
     @Override
     public DiffView getDiffs() {
         try {

--- a/src/main/java/io/specto/hoverfly/junit/core/model/Response.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/model/Response.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import sun.rmi.runtime.Log;
 
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/io/specto/hoverfly/junit/api/OkHttpHoverflyClientTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/api/OkHttpHoverflyClientTest.java
@@ -180,6 +180,20 @@ public class OkHttpHoverflyClientTest {
     }
 
     @Test
+    public void shouldBeAbleToAppendSimulation() throws Exception {
+        URL resource = Resources.getResource("simulations/v5-simulation.json");
+        Simulation simulation = objectMapper.readValue(resource, Simulation.class);
+        client.setSimulation(simulation);
+
+        resource = Resources.getResource("simulations/v5-simulation-without-response-body.json");
+        simulation = objectMapper.readValue(resource, Simulation.class);
+        client.addSimulation(simulation);
+
+        Simulation result = client.getSimulation();
+        assertThat(result.getHoverflyData().getPairs()).hasSize(2);
+    }
+
+    @Test
     public void shouldBeAbleToDeleteJournal() {
 
         try {


### PR DESCRIPTION
**WHAT**
This PR is adding a method to send a request to the [POST simulation](https://docs.hoverfly.io/en/latest/pages/reference/api/api.html#post-api-v2-simulation) endpoint of the admin API.

_Obs:_ I happened that I needed such feature so I implemented it and seemed to be a good idea to at least give you the opportunity to consider adding it to the main project. I gave a quick look at the opened issues, but couldn't find one for this, maybe I missed it.