### PR TITLE
Add support for configuring encodedBody in the DSL

### DIFF
--- a/src/main/java/io/specto/hoverfly/junit/dsl/ResponseBuilder.java
+++ b/src/main/java/io/specto/hoverfly/junit/dsl/ResponseBuilder.java
@@ -32,6 +32,7 @@ public class ResponseBuilder {
 
     private final Map<String, List<String>> headers = new HashMap<>();
     private String body = "";
+    private boolean encodedBody = false;
     private int status = 200;
     private boolean templated = true;
     private final Map<String, String> transitionsState = new HashMap<>();
@@ -113,7 +114,7 @@ public class ResponseBuilder {
      * @return the response
      */
     Response build() {
-        return new Response(status, body, false, templated, headers, transitionsState, removesState, fixedDelay, logNormalDelay);
+        return new Response(status, body, encodedBody, templated, headers, transitionsState, removesState, fixedDelay, logNormalDelay);
     }
 
     public ResponseBuilder body(final HttpBodyConverter httpBodyConverter) {
@@ -128,6 +129,14 @@ public class ResponseBuilder {
         return this;
     }
 
+    /**
+     * Sets the body as an encodedBody for binary responses
+     * @return the {@link ResponseBuilder for further customizations}
+     */
+    public ResponseBuilder binaryEncoding() {
+        this.encodedBody = true;
+        return this;
+    }
 
     /**
      * Set fixed delay for the request-response pair

--- a/src/test/java/io/specto/hoverfly/assertions/ResponseAssert.java
+++ b/src/test/java/io/specto/hoverfly/assertions/ResponseAssert.java
@@ -39,6 +39,14 @@ public class ResponseAssert extends AbstractAssert<ResponseAssert, Response> {
         return this;
     }
 
+    public ResponseAssert hasEncodedBody() {
+        isNotNull();
+
+        assertThat(actual.isEncodedBody()).isTrue();
+
+        return this;
+    }
+
     public ResponseAssert hasExactHeaders(final Header... headers) {
         isNotNull();
 

--- a/src/test/java/io/specto/hoverfly/junit/dsl/ResponseCreatorsTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/dsl/ResponseCreatorsTest.java
@@ -32,6 +32,21 @@ public class ResponseCreatorsTest {
     }
 
     @Test
+    public void shouldBuildSuccessResponseWithBinaryBodyAndContentType() {
+        // When
+        final Response response = ResponseCreators.success("Ym9keQ==", "contentType")
+                .binaryEncoding()
+                .build();
+
+        // Then
+        assertThat(response)
+                .hasStatus(200)
+                .hasBody("Ym9keQ==")
+                .hasEncodedBody()
+                .hasExactHeaders(header("Content-Type", "contentType"));
+    }
+
+    @Test
     public void shouldBuildSuccessResponse() {
         // When
         final Response response = ResponseCreators.success().build();


### PR DESCRIPTION
It is currently not possible to use the java DSL to create a simulation that contains a response with a binary body.

This PR introduces a small extension to the ResponseBuilder to allow switching the `encodedBody` value to true.