### PR TITLE
Include linux arm64 binary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,7 @@ task (updateHoverflyBinaries) {
             src([
                     "$downloadUrl/$hoverfly_binary_version/hoverfly_bundle_linux_386.zip",
                     "$downloadUrl/$hoverfly_binary_version/hoverfly_bundle_linux_amd64.zip",
+                    "$downloadUrl/$hoverfly_binary_version/hoverfly_bundle_linux_arm64.zip",
                     "$downloadUrl/$hoverfly_binary_version/hoverfly_bundle_OSX_amd64.zip",
                     "$downloadUrl/$hoverfly_binary_version/hoverfly_bundle_OSX_arm64.zip",
                     "$downloadUrl/$hoverfly_binary_version/hoverfly_bundle_windows_386.zip",


### PR DESCRIPTION
This should mean hoverfly works within docker images running on arm macs, which currently doesn't work as discussed here:

https://gitlab.com/openid/conformance-suite/-/commit/5bf13143f3d5ac37048436357749bea6a7c78c8b#note_1343474787