### PR TITLE
Inherit Hoverfly annotations

### DIFF
--- a/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflyCapture.java
+++ b/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflyCapture.java
@@ -3,6 +3,7 @@ package io.specto.hoverfly.junit5.api;
 import io.specto.hoverfly.junit5.HoverflyExtension;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -12,6 +13,7 @@ import java.lang.annotation.Target;
  * By default, it exports captured simulation file to default Hoverfly test resources path ("src/test/resources/hoverfly")
  * with filename equals to the fully qualified class name of the annotated class.
  */
+@Inherited
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HoverflyCapture {

--- a/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflyCore.java
+++ b/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflyCore.java
@@ -4,6 +4,7 @@ import io.specto.hoverfly.junit.core.HoverflyMode;
 import io.specto.hoverfly.junit5.HoverflyExtension;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -11,6 +12,7 @@ import java.lang.annotation.Target;
 /**
  * Use with {@link HoverflyExtension} to set mode and configuration. It does not trigger automatic import or export simulations.
  */
+@Inherited
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HoverflyCore {

--- a/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflyDiff.java
+++ b/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflyDiff.java
@@ -2,6 +2,7 @@ package io.specto.hoverfly.junit5.api;
 
 import io.specto.hoverfly.junit5.HoverflyExtension;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -11,6 +12,7 @@ import java.lang.annotation.Target;
  * By default, it tries to compare simulation file from default Hoverfly test resources path ("src/test/resources/hoverfly")
  * with filename equals to the fully qualified class name of the annotated class.
  */
+@Inherited
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HoverflyDiff {

--- a/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflySimulate.java
+++ b/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflySimulate.java
@@ -3,6 +3,7 @@ package io.specto.hoverfly.junit5.api;
 import io.specto.hoverfly.junit5.HoverflyExtension;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -12,6 +13,7 @@ import java.lang.annotation.Target;
  * By default, it tries to import simulation file from default Hoverfly test resources path ("src/test/resources/hoverfly")
  * with filename equals to the fully qualified class name of the annotated class.
  */
+@Inherited
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HoverflySimulate {

--- a/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflySpy.java
+++ b/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflySpy.java
@@ -4,6 +4,7 @@ import io.specto.hoverfly.junit5.HoverflyExtension;
 
 import io.specto.hoverfly.junit5.api.HoverflySimulate.Source;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -13,6 +14,7 @@ import java.lang.annotation.Target;
  * In this mode, Hoverfly simulates external APIs if a request match is found in simulation data
  * (See Simulate mode), otherwise, the request will be passed through to the real API.
  */
+@Inherited
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HoverflySpy {

--- a/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflyValidate.java
+++ b/junit5/src/main/java/io/specto/hoverfly/junit5/api/HoverflyValidate.java
@@ -1,6 +1,7 @@
 package io.specto.hoverfly.junit5.api;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -9,6 +10,7 @@ import java.lang.annotation.Target;
  * Annotation used to verify if any discrepancy is detected.
  * Can be used at class and method level.
  */
+@Inherited
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HoverflyValidate {


### PR DESCRIPTION
Mark all Hoverfly mode annotations as `@Inherited` to simplify complex tests setup.

This makes the annotation lookup mechanism to check superclasses as well.