### PR TITLE
Allow health check timeout configuration

### DIFF
--- a/src/main/java/io/specto/hoverfly/junit/core/HoverflyConstants.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/HoverflyConstants.java
@@ -1,10 +1,16 @@
 package io.specto.hoverfly.junit.core;
 
+import java.time.Duration;
+
 public class HoverflyConstants {
 
     public static final int DEFAULT_PROXY_PORT = 8500;
     public static final int DEFAULT_ADMIN_PORT = 8888;
     public static final int DEFAULT_HTTPS_ADMIN_PORT = 443;
+
+    // Timeout
+    public static final Duration DEFAULT_HEALTH_CHECK_TIMEOUT = Duration.ofSeconds(10);
+    public static final Duration DEFAULT_HEALTH_CHECK_RETRY_INTERVAL = Duration.ofMillis(100);
 
     // Hoverfly custom auth header name
     public static final String X_HOVERFLY_AUTHORIZATION = "X-HOVERFLY-AUTHORIZATION";

--- a/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfigValidator.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfigValidator.java
@@ -3,14 +3,13 @@ package io.specto.hoverfly.junit.core.config;
 import io.specto.hoverfly.junit.core.Hoverfly;
 import io.specto.hoverfly.junit.core.HoverflyConfig;
 import io.specto.hoverfly.junit.core.HoverflyConstants;
-import java.net.URL;
-import java.nio.file.Paths;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Optional;
 
 
@@ -67,6 +66,14 @@ class HoverflyConfigValidator {
             if (hoverflyConfig.getAdminPort() == 0) {
                 hoverflyConfig.setAdminPort(findUnusedPort());
             }
+        }
+
+        if (hoverflyConfig.getHealthCheckTimeout() == null) {
+            hoverflyConfig.setHealthCheckTimeout(HoverflyConstants.DEFAULT_HEALTH_CHECK_TIMEOUT);
+        }
+
+        if (hoverflyConfig.getHealthCheckRetryInterval() == null) {
+            hoverflyConfig.setHealthCheckRetryInterval(HoverflyConstants.DEFAULT_HEALTH_CHECK_RETRY_INTERVAL);
         }
 
         // Check proxy CA cert exists

--- a/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfiguration.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfiguration.java
@@ -4,6 +4,7 @@ import io.specto.hoverfly.junit.core.Hoverfly;
 import io.specto.hoverfly.junit.core.SimulationPreprocessor;
 import org.slf4j.Logger;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,6 +48,8 @@ public class HoverflyConfiguration {
     private String clientCaCertPath;
     private String responseBodyFilesPath;
     private boolean isRelativeResponseBodyFilesPath;
+    private Duration healthCheckTimeout;
+    private Duration healthCheckRetryInterval;
 
     /**
      * Create configurations for external hoverfly
@@ -352,5 +355,21 @@ public class HoverflyConfiguration {
 
     public void setRelativeResponseBodyFilesPath(boolean relativeResponseBodyFilesPath) {
         isRelativeResponseBodyFilesPath = relativeResponseBodyFilesPath;
+    }
+
+    public Duration getHealthCheckTimeout() {
+        return healthCheckTimeout;
+    }
+
+    public void setHealthCheckTimeout(Duration healthCheckTimeout) {
+        this.healthCheckTimeout = healthCheckTimeout;
+    }
+
+    public Duration getHealthCheckRetryInterval() {
+        return healthCheckRetryInterval;
+    }
+
+    public void setHealthCheckRetryInterval(Duration healthCheckRetryInterval) {
+        this.healthCheckRetryInterval = healthCheckRetryInterval;
     }
 }

--- a/src/main/java/io/specto/hoverfly/junit/core/config/LocalHoverflyConfig.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/LocalHoverflyConfig.java
@@ -14,12 +14,14 @@ package io.specto.hoverfly.junit.core.config;
 
 import io.specto.hoverfly.junit.core.Hoverfly;
 import io.specto.hoverfly.junit.core.HoverflyConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Config builder interface for settings specific to {@link Hoverfly} managed internally
@@ -40,6 +42,8 @@ public class LocalHoverflyConfig extends HoverflyConfig {
     private String clientKeyPath;
     private String clientAuthDestination;
     private String clientCaCertPath;
+    private Duration healthCheckTimeout;
+    private Duration healthCheckRetryInterval;
 
     /**
      * Sets the certificate file to override the default Hoverfly's CA cert
@@ -202,6 +206,26 @@ public class LocalHoverflyConfig extends HoverflyConfig {
         return this;
     }
 
+    /**
+     * Set the maximum time to wait for Hoverfly to be healthy.
+     * @param healthCheckTimeout the health check timeout
+     * @return the {@link HoverflyConfig} for further customizations
+     */
+    public HoverflyConfig healthCheckTimeout(Duration healthCheckTimeout) {
+        this.healthCheckTimeout = healthCheckTimeout;
+        return this;
+    }
+
+    /**
+     * Set the interval between health checks.
+     * @param healthCheckRetryInterval the health check retry interval
+     * @return the {@link HoverflyConfig} for further customizations
+     */
+    public HoverflyConfig healthCheckRetryInterval(Duration healthCheckRetryInterval) {
+        this.healthCheckRetryInterval = healthCheckRetryInterval;
+        return this;
+    }
+
     @Override
     public HoverflyConfiguration build() {
         HoverflyConfiguration configs = new HoverflyConfiguration(proxyPort, adminPort, proxyLocalHost, destination,
@@ -220,6 +244,8 @@ public class LocalHoverflyConfig extends HoverflyConfig {
         configs.setClientCaCertPath(clientCaCertPath);
         configs.setResponseBodyFilesPath(responseBodyFilesPath);
         configs.setRelativeResponseBodyFilesPath(isRelativeResponseBodyFilesPath);
+        configs.setHealthCheckTimeout(healthCheckTimeout);
+        configs.setHealthCheckRetryInterval(healthCheckRetryInterval);
         HoverflyConfigValidator validator = new HoverflyConfigValidator();
         return validator.validate(configs);
     }

--- a/src/main/java/io/specto/hoverfly/junit/core/config/RemoteHoverflyConfig.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/RemoteHoverflyConfig.java
@@ -4,6 +4,8 @@ import io.specto.hoverfly.junit.core.Hoverfly;
 import io.specto.hoverfly.junit.core.HoverflyConfig;
 import io.specto.hoverfly.junit.core.HoverflyConstants;
 
+import java.time.Duration;
+
 import static io.specto.hoverfly.junit.core.HoverflyConstants.DEFAULT_ADMIN_PORT;
 import static io.specto.hoverfly.junit.core.HoverflyConstants.DEFAULT_PROXY_PORT;
 
@@ -16,6 +18,8 @@ public class RemoteHoverflyConfig extends HoverflyConfig {
     private String scheme;
     private String authToken;
     private String adminCertificate; // file name relative to test resources folder
+    private Duration healthCheckTimeout;
+    private Duration healthCheckRetryInterval;
 
 
     /**
@@ -59,6 +63,26 @@ public class RemoteHoverflyConfig extends HoverflyConfig {
         return this;
     }
 
+    /**
+     * Set the maximum time to wait for Hoverfly to be healthy.
+     * @param healthCheckTimeout the health check timeout
+     * @return the {@link HoverflyConfig} for further customizations
+     */
+    public HoverflyConfig healthCheckTimeout(Duration healthCheckTimeout) {
+        this.healthCheckTimeout = healthCheckTimeout;
+        return this;
+    }
+
+    /**
+     * Set the interval between health checks.
+     * @param healthCheckRetryInterval the health check retry interval
+     * @return the {@link HoverflyConfig} for further customizations
+     */
+    public HoverflyConfig healthCheckRetryInterval(Duration healthCheckRetryInterval) {
+        this.healthCheckRetryInterval = healthCheckRetryInterval;
+        return this;
+    }
+
     // TODO add support for custom server certificate for admin endpoint
 
     @Override
@@ -72,6 +96,8 @@ public class RemoteHoverflyConfig extends HoverflyConfig {
         HoverflyConfiguration configs = new HoverflyConfiguration(scheme, host, proxyPort, adminPort, proxyLocalHost,
                 destination, proxyCaCert, authToken, adminCertificate, captureHeaders, webServer, statefulCapture, incrementalCapture,
                 simulationPreprocessor);
+        configs.setHealthCheckTimeout(healthCheckTimeout);
+        configs.setHealthCheckRetryInterval(healthCheckRetryInterval);
         HoverflyConfigValidator validator = new HoverflyConfigValidator();
         return validator.validate(configs);
     }

--- a/src/test/java/io/specto/hoverfly/junit/core/HoverflyConfigTest.java
+++ b/src/test/java/io/specto/hoverfly/junit/core/HoverflyConfigTest.java
@@ -1,19 +1,19 @@
 package io.specto.hoverfly.junit.core;
 
 import io.specto.hoverfly.junit.core.config.HoverflyConfiguration;
-import java.net.InetSocketAddress;
-import java.util.Optional;
-
 import io.specto.hoverfly.junit.core.config.LogLevel;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.Optional;
+
 import static io.specto.hoverfly.junit.core.HoverflyConfig.localConfigs;
 import static io.specto.hoverfly.junit.core.HoverflyConfig.remoteConfigs;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 public class HoverflyConfigTest {
@@ -47,6 +47,9 @@ public class HoverflyConfigTest {
         assertThat(configs.getClientKeyPath()).isNull();
         assertThat(configs.getClientAuthDestination()).isNull();
         assertThat(configs.getClientCaCertPath()).isNull();
+
+        assertThat(configs.getHealthCheckTimeout()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(configs.getHealthCheckRetryInterval()).isEqualTo(Duration.ofMillis(100));
     }
 
     @Test
@@ -237,4 +240,31 @@ public class HoverflyConfigTest {
         assertThat(configs.getClientCaCertPath()).isEqualTo("ssl/ca.pem");
     }
 
+    @Test
+    public void shouldSetHealthCheckTimeoutInLocalConfig() {
+        HoverflyConfiguration configs = localConfigs().healthCheckTimeout(Duration.ofSeconds(20)).build();
+
+        assertThat(configs.getHealthCheckTimeout()).isEqualTo(Duration.ofSeconds(20));
+    }
+
+    @Test
+    public void shouldSetHealthCheckRetryIntervalInLocalConfig() {
+        HoverflyConfiguration configs = localConfigs().healthCheckRetryInterval(Duration.ofSeconds(5)).build();
+
+        assertThat(configs.getHealthCheckRetryInterval()).isEqualTo(Duration.ofSeconds(5));
+    }
+
+    @Test
+    public void shouldSetHealthCheckTimeoutInRemoteConfig() {
+        HoverflyConfiguration configs = remoteConfigs().healthCheckTimeout(Duration.ofSeconds(20)).build();
+
+        assertThat(configs.getHealthCheckTimeout()).isEqualTo(Duration.ofSeconds(20));
+    }
+
+    @Test
+    public void shouldSetHealthCheckRetryIntervalInRemoteConfig() {
+        HoverflyConfiguration configs = remoteConfigs().healthCheckRetryInterval(Duration.ofSeconds(5)).build();
+
+        assertThat(configs.getHealthCheckRetryInterval()).isEqualTo(Duration.ofSeconds(5));
+    }
 }


### PR DESCRIPTION
On CI we sometimes see that the hardcoded 10 seconds is not enough for Hoverfly to become healthy. It would be nice to customize this value to stabilize our pipeline.