### PR TITLE
Generate Windows-friendly absolute paths from classpath resource URLs

### DIFF
--- a/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfigValidator.java
+++ b/src/main/java/io/specto/hoverfly/junit/core/config/HoverflyConfigValidator.java
@@ -10,6 +10,7 @@ import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Optional;
 
 
@@ -116,6 +117,14 @@ class HoverflyConfigValidator {
     private Optional<String> getTestResourcesFolderPath(String relativePath) {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         URL url = classLoader.getResource(relativePath);
-        return Optional.ofNullable(url).map(URL::getPath);
+        return Optional.ofNullable(url).map(this::toPath);
+    }
+
+    private String toPath(URL url) {
+        try {
+            return Path.of(url.toURI()).toString();
+        } catch (URISyntaxException e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
The `java.nio.file.Path` API generates absolute paths that are valid on Windows. Builds on Mac continue to work for me with this change.

Filesystem-specific tests might be a nice-to-have but I admit it's not something I've seen done or would know how to do off the top of my head.